### PR TITLE
Reduce test image size

### DIFF
--- a/tests/e2e/tests.sh
+++ b/tests/e2e/tests.sh
@@ -46,12 +46,12 @@ function test_pull_non_existent() {
 
 function test_push_pull() {
     local name=$1
-    docker rmi ubuntu:latest localhost:5000/$name/ubuntu:latest || :
-    docker pull ubuntu:latest
-    docker tag ubuntu:latest localhost:5000/$name/ubuntu:latest
-    docker push localhost:5000/$name/ubuntu:latest
-    docker rmi ubuntu:latest localhost:5000/$name/ubuntu:latest
-    docker pull localhost:5000/$name/ubuntu:latest
+    docker rmi alpine:latest localhost:5000/$name/alpine:latest || :
+    docker pull alpine:latest
+    docker tag alpine:latest localhost:5000/$name/alpine:latest
+    docker push localhost:5000/$name/alpine:latest
+    docker rmi alpine:latest localhost:5000/$name/alpine:latest
+    docker pull localhost:5000/$name/alpine:latest
 }
 
 


### PR DESCRIPTION
Just not to send back and forth 86M-long `ubuntu` image, but instead run tests with the 4.5M-long `alpine` image. 
NOTE: this PR will conflict with PR https://github.com/neuromation/platform-registry-api/pull/34 (Docker image list), it's better to merge the current PR before the other one.