### PR TITLE
temporary create another ingress host with ai.neuromation.io

### DIFF
--- a/deploy/platformregistryapi/templates/platformregistryapi.yml
+++ b/deploy/platformregistryapi/templates/platformregistryapi.yml
@@ -83,3 +83,10 @@ spec:
         backend:
           serviceName: platformregistryapi
           servicePort: 8080
+  - host: {{ printf "%s" (pluck .Values.global.env .Values.INGRESS_HOST_TEMPORARY | first | default .Values.INGRESS_HOST_TEMPORARY._default) }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: platformregistryapi
+          servicePort: 8080

--- a/deploy/platformregistryapi/values.yaml
+++ b/deploy/platformregistryapi/values.yaml
@@ -13,6 +13,11 @@ INGRESS_HOST:
   dev: registry.dev.neuromation.io
   staging: registry.staging.neuromation.io
   hse: registry.hse.neuromation.io
+INGRESS_HOST_TEMPORARY:
+  _default: registry-dev.ai.neuromation.io
+  dev: registry-dev.ai.neuromation.io
+  staging: registry-staging.ai.neuromation.io
+  hse: registry-hse.ai.neuromation.io
 NP_REGISTRY_AUTH_URL:
   _default: http://platformauthapi:8080
   dev: http://platformauthapi:8080


### PR DESCRIPTION
https://github.com/neuromation/platform-api/issues/448
In order to make the switch of cnames without downtime, we will create in parallel  new cnames with ai.neuromation.io and after we deploy on all the environments we will remove the old cnames.