### PR TITLE
remove old ingress hosts

### DIFF
--- a/deploy/platformregistryapi/templates/platformregistryapi.yml
+++ b/deploy/platformregistryapi/templates/platformregistryapi.yml
@@ -103,7 +103,6 @@ metadata:
     external-dns.platform.neuromation.io: "true"
 spec:
   rules:
-  {{- if .Values.INGRESS_HOST }}
   - host: {{ .Values.INGRESS_HOST }}
     http:
       paths:
@@ -111,23 +110,4 @@ spec:
         backend:
           serviceName: platformregistryapi
           servicePort: 8080
-  {{- end }}
-  {{- if .Values.INGRESS_HOST_TEMPORARY }}
-  - host: {{ .Values.INGRESS_HOST_TEMPORARY }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: platformregistryapi
-          servicePort: 8080
-  {{- end }}
-  {{- if .Values.INGRESS_HOST_TEMPORARY_NEW_DOMAIN }}
-  - host: {{ .Values.INGRESS_HOST_TEMPORARY_NEW_DOMAIN }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: platformregistryapi
-          servicePort: 8080
-  {{- end }}
 

--- a/deploy/platformregistryapi/values-dev.yaml
+++ b/deploy/platformregistryapi/values-dev.yaml
@@ -1,8 +1,6 @@
 IMAGE:
 NP_REGISTRY_UPSTREAM_PROJECT: light-reality-205619
-INGRESS_HOST: registry.dev.neuromation.io
-INGRESS_HOST_TEMPORARY: registry-dev.ai.neuromation.io
-INGRESS_HOST_TEMPORARY_NEW_DOMAIN: registry-dev.neu.ro
+INGRESS_HOST: registry-dev.neu.ro
 NP_REGISTRY_AUTH_URL: http://platformauthapi:8080
 NP_REGISTRY_UPSTREAM_URL: https://gcr.io
 NP_REGISTRY_UPSTREAM_TYPE: oauth

--- a/deploy/platformregistryapi/values-staging.yaml
+++ b/deploy/platformregistryapi/values-staging.yaml
@@ -1,8 +1,6 @@
 IMAGE: 
 NP_REGISTRY_UPSTREAM_PROJECT: light-reality-205619
-INGRESS_HOST: registry.staging.neuromation.io
-INGRESS_HOST_TEMPORARY: registry-staging.ai.neuromation.io
-INGRESS_HOST_TEMPORARY_NEW_DOMAIN: registry-staging.neu.ro
+INGRESS_HOST: registry-staging.neu.ro
 NP_REGISTRY_AUTH_URL: http://platformauthapi:8080
 NP_REGISTRY_UPSTREAM_URL: https://gcr.io
 NP_REGISTRY_UPSTREAM_TYPE: oauth

--- a/deploy/platformregistryapi/values-template.yaml
+++ b/deploy/platformregistryapi/values-template.yaml
@@ -1,8 +1,6 @@
 IMAGE: neuro-docker-local-public.jfrog.io/platformregistryapi:IMAGE_TAG
 NP_REGISTRY_UPSTREAM_PROJECT: ''
 INGRESS_HOST: ''
-INGRESS_HOST_TEMPORARY: ''
-INGRESS_HOST_TEMPORARY_NEW_DOMAIN: ''
 NP_REGISTRY_AUTH_URL: http://platformauthapi:8080
 NP_REGISTRY_UPSTREAM_URL: https://gcr.io
 NP_REGISTRY_UPSTREAM_TYPE: oauth


### PR DESCRIPTION
remove extra `INGRESS_HOST_TEMPORARY` and `INGRESS_HOST_TEMPORARY_NEW_DOMAIN`
keep only `INGRESS_HOST` with proper values