### PR TITLE
Add slashes support for repository name

### DIFF
--- a/platform_registry_api/api.py
+++ b/platform_registry_api/api.py
@@ -497,8 +497,8 @@ class V2Handler:
     async def _handle_aws_ecr_tags_list(
         self, registry_repo_url: RepoURL, request: Request, url_factory: URLFactory
     ) -> Response:
-        _, _, user, *repository, _, _ = request.path.split("/")
-        repository = "/".join(repository)
+        _, _, user, *repository_components, _, _ = request.path.split("/")
+        repository = "/".join(repository_components)
         args = {
             "repositoryName": f"{self._upstream_registry_config.project}/"
             f"{user}/{repository}",


### PR DESCRIPTION
Tested manually with

* `aaa/bbb/username/reponame/ddd/eee` → repository = `reponame`
* `aaa/bbb/username/repo/na/m/e/ddd/eee` → repository = `repo/na/m/e`