### PR TITLE
Try to fix AWS ECR delete image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-aiobotocore==1.3.3
 black==21.7b0
 flake8==3.9.2
 flake8-isort==4.0.0
 isort==5.9.2
 mypy==0.910
-platform-logging==21.5.27
 pre-commit==2.13.0
 pytest==6.2.4
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
New logic for AWS:
* Delete image tag
* Get images from the repository
* If zero images returned, issue a `delete_repository` request to AWS ECR