### PR TITLE
IT-114: Strip cookies from proxied registry traffic

### DIFF
--- a/platform_registry_api/upstream_client.py
+++ b/platform_registry_api/upstream_client.py
@@ -258,8 +258,8 @@ class UpstreamV2ApiClient:
         path_suffix = request.match_info["path_suffix"]
 
         headers = request.headers.copy()
-        for name in ("Host", "Transfer-Encoding", "Connection"):
-            headers.pop(name, None)
+        for name in ("Host", "Transfer-Encoding", "Connection", "Cookie"):
+            headers.popall(name, None)
 
         if self._is_pull_request(request):
             data = None
@@ -286,8 +286,13 @@ class UpstreamV2ApiClient:
             timeout=self._client_timeout(request),
         ) as client_response:
             response_headers = client_response.headers.copy()
-            for name in ("Transfer-Encoding", "Content-Encoding", "Connection"):
-                response_headers.pop(name, None)
+            for name in (
+                "Transfer-Encoding",
+                "Content-Encoding",
+                "Connection",
+                "Set-Cookie",
+            ):
+                response_headers.popall(name, None)
 
             if "Location" in response_headers:
                 location_url = URL(response_headers["Location"])

--- a/platform_registry_api/upstream_client.py
+++ b/platform_registry_api/upstream_client.py
@@ -16,6 +16,14 @@ from .config import UpstreamRegistryConfig
 
 LOGGER = logging.getLogger(__name__)
 
+PROXY_STRIP_REQUEST_HEADERS = ("Host", "Transfer-Encoding", "Connection", "Cookie")
+PROXY_STRIP_RESPONSE_HEADERS = (
+    "Transfer-Encoding",
+    "Content-Encoding",
+    "Connection",
+    "Set-Cookie",
+)
+
 
 class UpstreamApiException(Exception):
     def __init__(self, *, code: int, message: str):
@@ -258,7 +266,7 @@ class UpstreamV2ApiClient:
         path_suffix = request.match_info["path_suffix"]
 
         headers = request.headers.copy()
-        for name in ("Host", "Transfer-Encoding", "Connection", "Cookie"):
+        for name in PROXY_STRIP_REQUEST_HEADERS:
             headers.popall(name, None)
 
         if self._is_pull_request(request):
@@ -286,12 +294,7 @@ class UpstreamV2ApiClient:
             timeout=self._client_timeout(request),
         ) as client_response:
             response_headers = client_response.headers.copy()
-            for name in (
-                "Transfer-Encoding",
-                "Content-Encoding",
-                "Connection",
-                "Set-Cookie",
-            ):
+            for name in PROXY_STRIP_RESPONSE_HEADERS:
                 response_headers.popall(name, None)
 
             if "Location" in response_headers:

--- a/tests/unit/test_proxy_cookies.py
+++ b/tests/unit/test_proxy_cookies.py
@@ -1,0 +1,89 @@
+from collections.abc import Awaitable, Callable
+
+import pytest
+from aiohttp.test_utils import TestServer as _TestServer
+from aiohttp.web import Application, Request, StreamResponse, json_response
+
+from platform_registry_api.config import (
+    UpstreamRegistryConfig,
+    UpstreamType,
+)
+from platform_registry_api.upstream_client import UpstreamV2ApiClient
+
+
+_TestServerFactory = Callable[[Application], Awaitable[_TestServer]]
+_TestClientFactory = Callable[..., Awaitable[object]]
+
+
+class _UpstreamHandler:
+    def __init__(self) -> None:
+        self.received_cookie_headers: list[str] = []
+
+    async def handle(self, request: Request) -> StreamResponse:
+        self.received_cookie_headers.extend(request.headers.getall("Cookie", []))
+        return json_response(
+            {},
+            headers={"Set-Cookie": "sid=upstream-session; Path=/; HttpOnly"},
+        )
+
+
+class TestProxyCookies:
+    @pytest.fixture
+    async def upstream_handler(self) -> _UpstreamHandler:
+        return _UpstreamHandler()
+
+    @pytest.fixture
+    async def proxy_client(
+        self,
+        aiohttp_server: _TestServerFactory,
+        aiohttp_client: _TestClientFactory,
+        upstream_handler: _UpstreamHandler,
+    ) -> object:
+        upstream_app = Application()
+        upstream_app.router.add_route("*", "/v2/{tail:.+}", upstream_handler.handle)
+        upstream_server = await aiohttp_server(upstream_app)
+
+        config = UpstreamRegistryConfig(
+            type=UpstreamType.BASIC,
+            endpoint_url=upstream_server.make_url(""),
+            project="testproject",
+            basic_username="testuser",
+            basic_password="testpassword",
+        )
+        upstream_client = UpstreamV2ApiClient(config=config)
+        await upstream_client.__aenter__()
+
+        async def handle(request: Request) -> StreamResponse:
+            return await upstream_client.proxy_request(request)
+
+        proxy_app = Application()
+        proxy_app.router.add_route(
+            "*",
+            r"/v2/{repo:.+}/{path_suffix:(tags|manifests|blobs)/.*}",
+            handle,
+        )
+
+        async def close_upstream(app: Application) -> None:
+            await upstream_client.aclose()
+
+        proxy_app.on_cleanup.append(lambda app: close_upstream(app))
+        return await aiohttp_client(proxy_app)
+
+    async def test_client_cookie_not_forwarded_to_upstream(
+        self, proxy_client: object, upstream_handler: _UpstreamHandler
+    ) -> None:
+        resp = await proxy_client.get(  # type: ignore[attr-defined]
+            "/v2/org/proj/img/manifests/latest",
+            headers={"Cookie": "sid=leaked-harbor-session"},
+        )
+        assert resp.status == 200
+        assert upstream_handler.received_cookie_headers == []
+
+    async def test_upstream_set_cookie_not_returned_to_client(
+        self, proxy_client: object, upstream_handler: _UpstreamHandler
+    ) -> None:
+        resp = await proxy_client.get(  # type: ignore[attr-defined]
+            "/v2/org/proj/img/manifests/latest"
+        )
+        assert resp.status == 200
+        assert resp.headers.getall("Set-Cookie", []) == []


### PR DESCRIPTION
## Summary

Server-side half of [IT-114](https://apolocloud.atlassian.net/browse/IT-114) (`apolo image rm` broken; client half — SDK Accept negotiation — is neuro-inc/apolo-cli#3489). Full 5-Whys RCA with per-step evidence is in the ticket; the part fixed here:

`proxy_request` copies headers in both directions stripping only hop-by-hop ones, so Harbor's `Set-Cookie: sid` leaks to clients and client `Cookie` headers are forwarded back to Harbor. Harbor rejects unsafe methods carrying its session cookie without a CSRF token, so any cookie-keeping client (apolo-sdk's aiohttp session; docker is unaffected only because it keeps no cookies) gets `403 FORBIDDEN: CSRF token not found in request` on manifest DELETE.

Proven surgically against the dev registry — DELETE requests identical except the Cookie header:
- no cookies → 202 (deleted)
- only Harbor's `sid` → 403 (fires even before manifest lookup)
- only the service's own `NEURO_REGISTRYAPI_SESSION` → 202

The fix adds `Cookie` (request side) and `Set-Cookie` (response side) to the existing strip lists, switching them to `popall` since these headers are multi-valued. This mirrors the `DummyCookieJar` the service already uses for its own upstream connection ("Harbor registry requires disable cookies for turn off csrf token validation"). The registry API is stateless with per-request auth — no functionality depends on these cookies; stripping the request side also cures clients whose cookie jars already hold the `sid`.

## Test plan

- new `tests/unit/test_proxy_cookies.py` (two-server proxy test): client cookie is not forwarded upstream; upstream Set-Cookie is not returned to the client — both fail on the unfixed code, pass now
- full unit suite: 42/42; ruff check/format and mypy clean

[IT-114]: https://apolocloud.atlassian.net/browse/IT-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
- full e2e with the service running locally (built with the repo Dockerfile, pointed at the real dev Harbor and port-forwarded platform-auth): GET via the fixed service returns zero Set-Cookie headers (the unfixed dev deployment leaks two), and a DELETE carrying a real Harbor `sid` cookie succeeds with 202 through the fixed service while the same request through the unfixed dev deployment gets 403 CSRF
- composition e2e: patched SDK (apolo-cli#3489) + a cookieless client jar — real `images.digest()` → `images.rm()` path deletes the manifest end-to-end