### PR TITLE
IT-134: keep registry serving when platform-events is unreachable

### DIFF
--- a/platform_registry_api/project_deleter.py
+++ b/platform_registry_api/project_deleter.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Self
 
@@ -14,6 +15,8 @@ from .upstream_client import UpstreamV2ApiClient
 
 logger = logging.getLogger(__name__)
 
+SUBSCRIBE_RETRY_DELAY = 60.0
+
 
 class ProjectDeleter:
     ADMIN_STREAM = StreamType("platform-admin")
@@ -24,20 +27,43 @@ class ProjectDeleter:
     ) -> None:
         self._upstream_client = upstream_client
         self._client = from_config(config)
+        self._subscribe_task: asyncio.Task[None] | None = None
 
     async def __aenter__(self) -> Self:
-        logger.info("Subscribe for %r", self.ADMIN_STREAM)
-        await self._client.subscribe_group(
-            self.ADMIN_STREAM, self._on_admin_event, auto_ack=True
-        )
-        logger.info("Subscribed")
+        if not await self._subscribe():
+            self._subscribe_task = asyncio.create_task(self._subscribe_later())
         return self
 
     async def __aexit__(self, exc_typ: object, exc_val: object, exc_tb: object) -> None:
         await self.aclose()
 
     async def aclose(self) -> None:
+        if self._subscribe_task is not None:
+            self._subscribe_task.cancel()
+            try:
+                await self._subscribe_task
+            except asyncio.CancelledError:
+                pass
+            self._subscribe_task = None
         await self._client.aclose()
+
+    async def _subscribe(self) -> bool:
+        try:
+            logger.info("Subscribe for %r", self.ADMIN_STREAM)
+            await self._client.subscribe_group(
+                self.ADMIN_STREAM, self._on_admin_event, auto_ack=True
+            )
+        except Exception:
+            logger.exception("Failed to subscribe for %r", self.ADMIN_STREAM)
+            return False
+        logger.info("Subscribed")
+        return True
+
+    async def _subscribe_later(self) -> None:
+        while True:
+            await asyncio.sleep(SUBSCRIBE_RETRY_DELAY)
+            if await self._subscribe():
+                return
 
     async def _on_admin_event(self, ev: RecvEvent) -> None:
         if ev.event_type == self.PROJECT_REMOVE:

--- a/tests/integration/test_project_deleter.py
+++ b/tests/integration/test_project_deleter.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -105,3 +106,22 @@ async def test_deleter(
         assert response.status == 200
         assert not resp["tags"]
         assert resp["name"] == "org/project/alpine"
+
+
+async def test_deleter_survives_unreachable_events(
+    aiohttp_client: _TestClientFactory,
+    config: Config,
+) -> None:
+    # an unreachable events endpoint must not break service startup
+    config = replace(
+        config,
+        events=EventsClientConfig(
+            url=URL("http://platform-events.invalid:8080"),
+            token="token",  # noqa: S106
+            name="platform-registry",
+        ),
+    )
+    app = await create_app(config)
+    client = await aiohttp_client(app)
+    async with client.get("/v2/") as response:
+        assert response.status == 401


### PR DESCRIPTION
## Problem

platform-registry-api 26.7.0 crashloops on the prod **compute** clusters (apolo-main, imdc): new pods never become Ready → Deployment "exceeded its progress deadline" → ArgoCD Degraded. (Rolled back to 24.11.1 in the meantime; no outage — the old ReplicaSet kept serving.)

## Root cause

`ProjectDeleter` subscribes to the `platform-admin` stream at startup, which opens a websocket to **platform-events** (`EventsClient.subscribe_group` → `RawEventsClient._lazy_init` → `ws_connect`). A connection failure there is **not** caught (`subscribe_group` only swallows `TimeoutError`), so it propagates out of the app's `cleanup_ctx` and crashes the process:

```
aiohttp ... self._ws = await self._session.ws_connect(...)
ClientConnectorDNSError: Cannot connect to host platform-events...:8080
→ CrashLoopBackOff
```

`platform-events` (and `platform-admin`) run **only on the control plane**; on the compute clusters — where the registry actually runs — the subscription can never connect, so the pod crashloops. 24.11.1 had no events dependency (and no probes), so it ran fine there.

## Fix

Make the subscription **non-fatal**: try to subscribe at startup; on failure, log it and **retry in the background**. Startup and request serving no longer depend on a live events connection. Behaviour is unchanged when events is reachable (fast synchronous subscribe, as before); on close the retry task is cancelled cleanly.

## Verification

- New test `test_deleter_survives_unreachable_events`: `create_app` + serve with an unreachable events URL (which previously crashed startup) → `/v2/` returns 401 as expected. Passes.
- `ruff` and `mypy` clean.
- Reproduced the original crash on dev by pointing a cloned registry deployment's `NP_REGISTRY_EVENTS_URL` at an unreachable host → CrashLoopBackOff with the `ws_connect` DNS stacktrace above; the fixed code survives the same condition.

Refs IT-134 — unblocks the IT-114 `image rm` fix reaching prod compute.